### PR TITLE
feat(CLI): Admin Features

### DIFF
--- a/assets/database.json
+++ b/assets/database.json
@@ -17,28 +17,78 @@
         }
     },
     "balance": {
-        "jim@dundlerwifflin.com": 500,
-        "schrute@dundlerwifflin.com": 100,
+        "jim@dundlerwifflin.com": 470,
+        "schrute@dundlerwifflin.com": 70,
         "glewis@dundlerwifflin.com": 100
     },
     "movement": {
         "jim@dundlerwifflin.com": [
             {
-                "data": "2022-08-20T16:16:44.137327",
+                "date": "2022-08-20T16:16:44.137327",
                 "actor": "system",
                 "value": 500
+            },
+            {
+                "date": "2022-08-21T10:22:52.859269",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:23:25.548759",
+                "actor": "river",
+                "value": -30
+            },
+            {
+                "date": "2022-08-21T10:26:36.406386",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:27:24.813033",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:27:40.021728",
+                "actor": "river",
+                "value": -30
             }
         ],
         "schrute@dundlerwifflin.com": [
             {
-                "data": "2022-08-20T16:16:44.138902",
+                "date": "2022-08-20T16:16:44.138902",
                 "actor": "system",
                 "value": 100
+            },
+            {
+                "date": "2022-08-21T10:22:52.859283",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:23:25.548772",
+                "actor": "river",
+                "value": -30
+            },
+            {
+                "date": "2022-08-21T10:26:36.406397",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:27:24.813044",
+                "actor": "river",
+                "value": 10
+            },
+            {
+                "date": "2022-08-21T10:27:40.021742",
+                "actor": "river",
+                "value": -30
             }
         ],
         "glewis@dundlerwifflin.com": [
             {
-                "data": "2022-08-20T16:16:44.139140",
+                "date": "2022-08-20T16:16:44.139140",
                 "actor": "system",
                 "value": 100
             }

--- a/dundie/cli.py
+++ b/dundie/cli.py
@@ -1,3 +1,5 @@
+import json
+
 import pkg_resources
 import rich_click as click
 from rich.console import Console
@@ -42,3 +44,48 @@ def load(filepath):
         table.add_row(*[str(value) for value in person.values()])
     console = Console()
     console.print(table)
+
+
+@main.command()
+@click.option('--dept', required=False)
+@click.option('--email', required=False)
+@click.option('--output', default=None)
+def show(output, **query):
+    """Shows information about users."""
+    result = core.read(**query)
+    if output:
+        with open(output, 'w') as output_file:
+            output_file.write(json.dumps(result))
+
+    if not result:
+        print('Nothing to show')
+
+    table = Table(title='Dunder Mifflin Report')
+    for key in result[0]:
+        table.add_column(key.title(), style='magenta')
+    for person in result:
+        table.add_row(*[str(value) for value in person.values()])
+    console = Console()
+    console.print(table)
+
+
+@main.command()
+@click.argument('value', type=click.INT, required=True)
+@click.option('--dept', required=False)
+@click.option('--email', required=False)
+@click.pass_context
+def add(ctx, value, **query):
+    """Add points to users or departements."""
+    core.add(value, **query)
+    ctx.invoke(show, **query)
+
+
+@main.command()
+@click.argument('value', type=click.INT, required=True)
+@click.option('--dept', required=False)
+@click.option('--email', required=False)
+@click.pass_context
+def remove(ctx, value, **query):
+    """Remove points to users or departements."""
+    core.add(-value, **query)
+    ctx.invoke(show, **query)

--- a/dundie/database.py
+++ b/dundie/database.py
@@ -68,7 +68,7 @@ def add_movement(db, pk, value, actor='system'):
     movments = db['movement'].setdefault(pk, [])
     movments.append(
         {
-            'data': datetime.now().isoformat(),
+            'date': datetime.now().isoformat(),
             'actor': actor,
             'value': value
         }

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,0 +1,26 @@
+import pytest
+
+from dundie.core import add
+from dundie.database import connect, add_person, commit
+
+
+@pytest.mark.unit
+def test_add_movement():
+    db = connect()
+    pk = 'joe@doe.com'
+    data = {'role': 'Salesman', 'dept': 'Sales', 'name': 'Joe Doe'}
+    _, created = add_person(db, pk, data)
+    assert created
+
+    pk = 'jim@doe.com'
+    data = {'role': 'Manager', 'dept': 'Management', 'name': 'Jim Doe'}
+    _, created = add_person(db, pk, data)
+    assert created
+    commit(db)
+
+    add(-30, email='joe@doe.com')
+    add(90, dept='Management')
+
+    db = connect()
+    assert db['balance']['joe@doe.com'] == 470
+    assert db['balance']['jim@doe.com'] == 190

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dundie.database import EMPTY_DB, add_person, commit, connect
+from dundie.database import EMPTY_DB, add_person, commit, connect, add_movement
 
 
 @pytest.mark.unit
@@ -48,3 +48,28 @@ def test_add_person_for_the_first_time():
 def test_negative_add_person_invalid_mail():
     with pytest.raises(ValueError):
         add_person({}, ".@blah", {})
+
+
+@pytest.mark.unit
+def test_add_or_points_for_person():
+    pk = 'joe@doe.com'
+    data = {
+        'role': 'Salesman',
+        'dept': 'Sales',
+        'name': 'Joe Doe'
+    }
+    db = connect()
+    _, created = add_person(db, pk, data)
+    assert created
+    commit(db)
+    db = connect()
+    before = db['balance'][pk]
+    add_movement(db, pk, -100, "manager")
+    commit(db)
+
+    db = connect()
+    after = db['balance'][pk]
+
+    assert after == before - 100
+    assert after == 400
+    assert before == 500

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,0 +1,30 @@
+import pytest
+
+from dundie.core import read
+from dundie.database import connect, add_person, commit
+
+
+@pytest.mark.unit
+def test_read_with_query():
+    db = connect()
+    pk = 'joe@doe.com'
+    data = {'role': 'Salesman', 'dept': 'Sales', 'name': 'Joe Doe'}
+    _, created = add_person(db, pk, data)
+    assert created
+
+    pk = 'jim@doe.com'
+    data = {'role': 'Manager', 'dept': 'Management', 'name': 'Jim Doe'}
+    _, created = add_person(db, pk, data)
+    assert created
+    commit(db)
+
+    respnse = read()
+    assert len(respnse) == 2
+
+    response = read(dept='Management')
+    assert len(response) == 1
+    assert response[0]['name'] == 'Jim Doe'
+
+    response = read(email='joe@doe.com')
+    assert len(response) == 1
+    assert response[0]['name'] == 'Joe Doe'


### PR DESCRIPTION
It implemented the following admin features:

- ADD -> allow admin to add points to employees or departments,
- REMOVE -> allow admin to remove points to employees or departments,
- SHOW -> allow admin to see a report to all employees, a single employee by its email or all employee specified by a department and also can be export this report in a file.

Closes #2 #3