### PR TITLE
chore(CLI): Improvements to build and publish the project at PYPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+ include tests/assets/*.csv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # HELP
 # This will output the help for each task
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
-.PHONY: help install venv ipython test pflake8 clean
+.PHONY: help install venv ipython test pflake8 clean lint build
 
 help: ## This help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -38,3 +38,9 @@ clean:  ## Clean unused files.
 	@rm -rf htmlcov
 	@rm -rf .tox/
 	@rm -rf docs/_build
+
+build:
+	@python setup.py sdist bdist_wheel
+
+publish-test:
+	@twine upload --repository testpypi dist/*

--- a/dundie/cli.py
+++ b/dundie/cli.py
@@ -16,7 +16,7 @@ click.rich_click.USE_RICH_MARKUP = True
 
 
 @click.group()
-@click.version_option(pkg_resources.get_distribution('dundie').version)
+@click.version_option(pkg_resources.get_distribution('vm-dundie').version)
 def main():
     """Dunder Mifflin Rewards System.
     This cli application controls Dunder Mifflin rewards.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,5 +8,9 @@ flake8==4.0.1
 pyproject-flake8
 isort
 
+
+# build
+wheel
+twine
 # Install project as editable
 -e .

--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,15 @@ def read_requirements(path):
 
 
 setup(
-    name='dundie',
+    name='vm-dundie',
     version='0.1.0',
     description='Reward Point System for Dunder Mifflin',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     author='Vicente Marçal',
     python_requires='>=3.8',
-    packages=find_packages(),
+    packages=find_packages(exclude=['integration']),
+    include_package_data=True,
     entry_points={
         'console_scripts': [
             'dundie = dundie.__main__:main'


### PR DESCRIPTION
Adjustments in the code as following:
- rename the project at setup.py,
- put the new name in click version decorator,
- installed the libs wheel and twice to build and publish the project at pypi
- created the new commands build and publish-test in Makefile
- created the file MANIFEST.in to include assets/people.csv in project build

Closes #26